### PR TITLE
Revert VERSION_11 to VERSION_1_8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,8 +18,8 @@ kotlinDslPluginOptions {
 }
 
 configure<JavaPluginConvention> {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 repositories {


### PR DESCRIPTION
Though it didn't show up during testing (and why?!),
this leads to a failure on trying to release downstream
components:

```
java.lang.UnsupportedClassVersionError: org/openmicroscopy/api/ApiPlugin
has been compiled by a more recent version of the Java Runtime (class
file version 55.0), this version of the Java Runtime only recognizes
class file versions up to 52.0 > org/openmicroscopy/api/ApiPlugin has
been compiled by a more recent version of the Java Runtime (class file
version 55.0), this version of the Java Runtime only recognizes class
file versions up to 52.0
```

see: https://trello.com/c/Tk1L87GB/107-point-to-review

cc: @rgozim @jburel 