### PR TITLE
Do not create multiple Maven publications

### DIFF
--- a/src/main/kotlin/org/openmicroscopy/PublishingPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/PublishingPlugin.kt
@@ -94,21 +94,6 @@ class PublishingPlugin : Plugin<Project> {
             }
 
             publications {
-                create<MavenPublication>("${camelCaseName()}Binary") {
-                    plugins.withType<JavaPlugin> {
-                        from(components["java"])
-                    }
-                    pom(standardPom())
-                }
-
-                create<MavenPublication>("${camelCaseName()}BinaryAndSources") {
-                    plugins.withType<JavaPlugin> {
-                        from(components["java"])
-                        artifact(tasks.getByName("sourcesJar"))
-                    }
-                    pom(standardPom())
-                }
-
                 create<MavenPublication>(camelCaseName()) {
                     plugins.withType<JavaPlugin> {
                         from(components["java"])


### PR DESCRIPTION
For SNAPSHOTS this will result int artifacts being upload in multiple
copies with incremental build numbers
For release artifacts, this results in errors of type
```
Multiple publications with coordinates 'org.openmicroscopy:omero-model:5.6.6' are published to repository 'artifactory2'. The publications will overwrite each other!
```

see https://github.com/ome/omero-model/runs/6692008977?check_suite_focus=true 

Proposed tag: `5.5.4`