### PR TITLE
remove deprecated html flag removed in newer version of Java

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "org.openmicroscopy"
-version = "5.5.4"
+version = "5.5.5-SNAPSHOT"
 
 kotlinDslPluginOptions {
     experimentalWarning.set(false)

--- a/buildSrc/src/main/kotlin/org/openmicroscopy/AdditionalArtifactsPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/openmicroscopy/AdditionalArtifactsPlugin.kt
@@ -23,9 +23,6 @@ class AdditionalArtifactsPlugin : Plugin<Project> {
                 // Configure java doc options
                 val stdOpts = options as StandardJavadocDocletOptions
                 stdOpts.addStringOption("Xdoclint:none", "-quiet")
-                if (JavaVersion.current().isJava9Compatible) {
-                    stdOpts.addBooleanOption("html5", true)
-                }
             }
 
             tasks.register<Jar>("sourcesJar") {

--- a/src/main/kotlin/org/openmicroscopy/AdditionalArtifactsPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/AdditionalArtifactsPlugin.kt
@@ -44,9 +44,6 @@ class AdditionalArtifactsPlugin : Plugin<Project> {
                 // Configure java doc options
                 val stdOpts = options as StandardJavadocDocletOptions
                 stdOpts.addStringOption("Xdoclint:none", "-quiet")
-                if (JavaVersion.current().isJava9Compatible) {
-                    stdOpts.addBooleanOption("html5", true)
-                }
             }
 
             tasks.register<Jar>("sourcesJar") {


### PR DESCRIPTION
Doc generation is failing in Java 11 in newer version of CI
``javadoc: error - invalid flag: -html5``
This removes the deprecated html5 options in JDK 11
